### PR TITLE
Disable PMIx for OpenMPI4 and Slurm

### DIFF
--- a/components/mpi-families/openmpi/SPECS/openmpi.spec
+++ b/components/mpi-families/openmpi/SPECS/openmpi.spec
@@ -32,7 +32,7 @@
 %{!?with_lustre: %define with_lustre 0}
 %{!?with_slurm: %define with_slurm 0}
 %{!?with_tm: %global with_tm 1}
-%{!?with_pmix: %define with_pmix 1}
+%{!?with_pmix: %define with_pmix 0}
 %{!?with_ofi: %define with_ofi 1}
 %{!?with_ucx: %define with_ucx 1}
 

--- a/components/mpi-families/openmpi/SPECS/openmpi.spec
+++ b/components/mpi-families/openmpi/SPECS/openmpi.spec
@@ -32,7 +32,8 @@
 %{!?with_lustre: %define with_lustre 0}
 %{!?with_slurm: %define with_slurm 0}
 %{!?with_tm: %global with_tm 1}
-%{!?with_pmix: %define with_pmix 0}
+
+%{!?with_pmix: %define with_pmix 1}
 %{!?with_ofi: %define with_ofi 1}
 %{!?with_ucx: %define with_ucx 1}
 

--- a/components/rms/slurm/SPECS/slurm.spec
+++ b/components/rms/slurm/SPECS/slurm.spec
@@ -10,7 +10,7 @@
 
 %include %{_sourcedir}/OHPC_macros
 %global _with_mysql  1
-%global _with_pmix --with-pmix=%{OHPC_ADMIN}/pmix
+#%global _with_pmix --with-pmix=%{OHPC_ADMIN}/pmix
 %global _with_hwloc 1
 %global _with_numa 1
 %global _with_slurmrestd 1


### PR DESCRIPTION
This is an attempt to pinpoint which change breaks the tests on openEuler and Leap